### PR TITLE
Allow same-host CMP webview links instead of forcing them into Safari

### DIFF
--- a/Changelogs/1.9.2
+++ b/Changelogs/1.9.2
@@ -1,0 +1,6 @@
+1.9.2 Release notes (2026-07-01)
+=============================================================
+
+### Changes
+
+* Fixed CMP webview links pointing at the same host as the currently loaded page (for example a same-page anchor used to reveal the trusted-partners vendor list) being cancelled and force-opened in Safari instead of being handled inside the webview

--- a/Example/RingPublishingGDPR.xcodeproj/project.pbxproj
+++ b/Example/RingPublishingGDPR.xcodeproj/project.pbxproj
@@ -420,7 +420,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.9.1;
+				MARKETING_VERSION = 1.9.2;
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -440,7 +440,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.9.1;
+				MARKETING_VERSION = 1.9.2;
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/RingPublishingGDPR.podspec
+++ b/RingPublishingGDPR.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name         = "RingPublishingGDPR"
-    s.version      = "1.9.1"
+    s.version      = "1.9.2"
     s.homepage     = "https://github.com/ringpublishing/RingPublishingGDPR-iOS"
     s.summary      = "Collects and saves user's consent in accordance with the standard TCF2.0"
     s.license      = { :type => 'Copyright. Ringier Axel Springer Polska', :file => 'LICENSE' }

--- a/Sources/RingPublishingGDPR/Classes/Private/GDPRManager+WKNavigationDelegate.swift
+++ b/Sources/RingPublishingGDPR/Classes/Private/GDPRManager+WKNavigationDelegate.swift
@@ -49,6 +49,16 @@ extension GDPRManager: WKNavigationDelegate {
             return
         }
 
+        // Links pointing at the same host as the currently loaded CMP page are internal
+        // navigations (for example same-page anchors used to reveal the vendor list) and
+        // should stay inside the webview instead of being sent to an external browser
+        if let linkUrl = navigationAction.request.url, linkUrl.host == webView.url?.host {
+            Logger.log("CMP: WebView decide policy - allow for same host url: \(navigationUrl.logable)")
+
+            decisionHandler(.allow)
+            return
+        }
+
         // Open link in Safari browser
         if let linkUrl = navigationAction.request.url, UIApplication.shared.canOpenURL(linkUrl) {
             Logger.log("CMP: WebView decide policy - opening in Safari: \(linkUrl)")


### PR DESCRIPTION
## Problem

`GDPRManager+WKNavigationDelegate.swift`'s `decidePolicyFor(navigationAction:)` treats **every** link tap inside the CMP webview (`navigationType == .linkActivated`) as an external link: it cancels the in-webview navigation and force-opens the URL in Safari, regardless of the link's target host.

This breaks links that are same-page/same-host navigations used by the CMP's own JavaScript to reveal content in place - for example the "Show list of Trusted IAB Partners" link on the settings/preferences screen, which navigates to the *same* currently-loaded CMP URL with just an empty fragment appended (`...index.html?...#`). The webview's own JS already updates the visible content correctly; the SDK's unconditional Safari redirect is an unwanted, unnecessary detour that also looks like a bug to end users (tap a link inside the consent screen, unexpectedly land in Safari, go back, list is already there).

Reproduced with a real tenant CMP configuration wired into the `Example` demo app (bundle unmodified in this PR - see commit history for the temporary local repro setup, not included in the final diff).

### Evidence (os_log, before the fix)

```
[GDPRManager+WKNavigationDelegate.swift:54] CMP: WebView decide policy - opening in Safari: https://<cmp-host>/.../index.html?...#
[GDPRManager+WKNavigationDelegate.swift:58] CMP: WebView decide policy - cancel for url: https://<cmp-host>/.../index.html?...#
```

Note the target URL is identical to the page already loaded in the webview (only the trailing `#` differs).

### Why Android does not exhibit this

`RingPublishingGDPR-Android`'s `CmpWebViewClient.shouldOverrideUrlLoading` already special-cases same-host navigations (`request.getUrl().getHost().contains(BuildConfig.CMP_HOST)` -> `return false`, let the WebView handle it). iOS has no equivalent check.

## Fix

Compare the navigation's target host against the **currently loaded** `webView.url` host, and `.allow` the navigation when they match - only navigations to a genuinely different host are cancelled and opened in Safari (unchanged behavior for real external links, e.g. a vendor's own privacy policy page).

This is intentionally derived dynamically from the loaded page rather than a hardcoded CMP host string (unlike the Android implementation), so it works correctly for any tenant's CMP domain without needing a per-tenant constant.

### After the fix (os_log)

```
[GDPRManager+WKNavigationDelegate.swift:56] CMP: WebView decide policy - allow for same host url: https://<cmp-host>/.../index.html?...#
```

No Safari launch; the webview stays on the CMP screen and shows the vendor list as expected.

## Commits

1. `Allow same-host CMP webview links instead of forcing them into Safari` - the actual fix
2. `Bumped 1.9.1 to 1.9.2` - changelog + version bump, following the same pattern as #25 / #26

## Testing

- Verified against a real production CMP tenant configuration via the `Example` demo app on iOS Simulator (iPhone 17 Pro, iOS 26.5): confirmed via `os_log` that the link now resolves through the new "allow for same host url" branch instead of "opening in Safari", and the vendor list renders in-app.
- Confirmed the previously-reported behavior (Safari opening) is 100% reproducible before this fix, and gone after it, using the identical tap on the identical link across three separate attempts.

## Compatibility

No public API changes. No changes to behavior for links pointing at a different host - those still open in Safari as before.
